### PR TITLE
test(legacy): add card characterization suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Run stabilization fault tests
         run: npm run test:stability
 
+      - name: Run legacy characterization unit tests
+        run: npm run test:legacy:unit
+
+      - name: Install characterization browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run legacy characterization journeys
+        run: npm run test:legacy:e2e
+
       - name: Build legacy application
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn.lock
 .env.dev
 out/
 .venv-specs/
+test-results/
+playwright-report/

--- a/components/NumberedGalleryImage.js
+++ b/components/NumberedGalleryImage.js
@@ -1,8 +1,10 @@
+const { getCardNumber } = require("../lib/legacyCardsBehavior");
+
 const NumberedGalleryImage = ({ photo, margin, onClick, index, key }) => {
   return (
     <>
       <div key={key} className="gallery-image">
-        <div className="gallery-image__number">{index + 1}</div>
+        <div className="gallery-image__number">{getCardNumber(index)}</div>
         <img
           onClick={() => onClick(undefined, { index })}
           style={{ margin, height: photo.height }}

--- a/docs/backlog/implementation-work-items.yaml
+++ b/docs/backlog/implementation-work-items.yaml
@@ -128,7 +128,7 @@ items:
     branch_name: agent/vib-stab-004-characterization
     commit_prefix: "test(legacy):"
     milestone: M1
-    status: in_progress
+    status: done
 
   - id: VIB-PLAT-001
     epic: Platform
@@ -159,7 +159,7 @@ items:
     branch_name: agent/vib-plat-001-app-router-shell
     commit_prefix: "feat(platform):"
     milestone: M2
-    status: planned
+    status: ready
 
   - id: VIB-PLAT-002
     epic: Platform

--- a/docs/backlog/implementation-work-items.yaml
+++ b/docs/backlog/implementation-work-items.yaml
@@ -128,7 +128,7 @@ items:
     branch_name: agent/vib-stab-004-characterization
     commit_prefix: "test(legacy):"
     milestone: M1
-    status: ready
+    status: in_progress
 
   - id: VIB-PLAT-001
     epic: Platform

--- a/lib/legacyCardsBehavior.js
+++ b/lib/legacyCardsBehavior.js
@@ -1,0 +1,36 @@
+(function exposeLegacyCardsBehavior(root, factory) {
+  const behavior = factory();
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = behavior;
+  }
+
+  if (root) {
+    root.LegacyCardsBehavior = behavior;
+  }
+})(typeof window !== "undefined" ? window : null, function createBehavior() {
+  const getDeckTableName = (authenticated) =>
+    authenticated ? "vibuco-photos" : "vibuco-photos-public";
+
+  const getPromptForLocale = (prompt, authenticated, locale = "en") => {
+    if (!authenticated || typeof prompt === "string") return prompt;
+    return prompt[locale] || prompt.en;
+  };
+
+  const getCardBackSource = (card) =>
+    card.width / card.height >= 1
+      ? "../static/green2.jpg"
+      : "../static/green1.jpg";
+
+  const getCardNumber = (index) => index + 1;
+
+  const shuffleWith = (cards, shuffler) => shuffler(cards);
+
+  return {
+    getCardBackSource,
+    getCardNumber,
+    getDeckTableName,
+    getPromptForLocale,
+    shuffleWith,
+  };
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "build": "node scripts/run-next.js build",
     "start": "node scripts/run-next.js start",
     "test:stability": "node --test tests/stability/*.test.js",
+    "test:legacy:unit": "node --test tests/legacy/*.test.js",
+    "test:legacy:e2e": "playwright test",
     "synthetic:cards": "node scripts/synthetic-cards.mjs",
     "pems:prepare": "prepare-pems --region $USER_POOL_REGION --userPoolId $USER_POOL_ID",
     "export": "npm run build && node scripts/run-next.js export"

--- a/pages/cards.js
+++ b/pages/cards.js
@@ -14,6 +14,12 @@ import _ from "lodash";
 import NumberedGalleryImage from "../components/NumberedGalleryImage";
 import Viheader from "../components/headers/viheader";
 import { NextSeo } from "next-seo";
+const {
+  getCardBackSource,
+  getDeckTableName,
+  getPromptForLocale,
+  shuffleWith,
+} = require("../lib/legacyCardsBehavior");
 
 import "../styles/customStyles.css";
 
@@ -74,7 +80,7 @@ const Cards = ({ initialAuth }) => {
   };
 
   const fetchPublicImagesData = async () => {
-    const imageData = await getDataFromDDBTable("vibuco-photos-public");
+    const imageData = await getDataFromDDBTable(getDeckTableName(false));
 
     // convert all s3 urls to https urls
     const imageDataWithSources = convertSourcesToHttps(
@@ -84,7 +90,7 @@ const Cards = ({ initialAuth }) => {
 
     const imagesWithWidth = await getImageWidths(imageDataWithSources);
     // shuffle images
-    setImages(_.shuffle(imagesWithWidth));
+    setImages(shuffleWith(imagesWithWidth, _.shuffle));
   };
 
    // encode file.Body response into a base64 string
@@ -97,7 +103,10 @@ const Cards = ({ initialAuth }) => {
 
   const fetchCommonImagesData = async () => {
     //const imageData = await getDataFromDDBTable("vibuco-photos", auth.idToken);
-    const imageData = await getDataFromDDBTable("vibuco-photos", auth.idToken);
+    const imageData = await getDataFromDDBTable(
+      getDeckTableName(true),
+      auth.idToken
+    );
 
     // presign our image urls for authenticated access
     const imageObjects = await getImageObjects(
@@ -120,7 +129,7 @@ const Cards = ({ initialAuth }) => {
 
     const data = await Promise.all(completeImageDataWithObjects);
 
-    setImages(_.shuffle(data));
+    setImages(shuffleWith(data, _.shuffle));
   }; 
 
   // Fetch the right data based on authentication (will happen on page load)
@@ -171,7 +180,7 @@ const Cards = ({ initialAuth }) => {
   // still using dynamo db to get all the metadata
   // so both paces need to be updated when adding new photo
   const fetchCommonImagesDataFromStatic = async () => {
-    const imageData = await getDataFromDDBTable("vibuco-photos-public");
+    const imageData = await getDataFromDDBTable(getDeckTableName(false));
 
 
    const completeImageDataWithObjects = imageData.map(async (img, i) => {
@@ -190,7 +199,7 @@ const Cards = ({ initialAuth }) => {
 
     const data = await Promise.all(completeImageDataWithObjects);
 
-    setImages(_.shuffle(data));
+    setImages(shuffleWith(data, _.shuffle));
   }; 
 
   const retryLoad = () => setLoadAttempt((attempt) => attempt + 1);
@@ -200,7 +209,7 @@ const Cards = ({ initialAuth }) => {
   // shuffle images whenever we flip from backgrounds back to normal images
   useEffect(() => {
     if (!isFlipped) {
-      setImages((prevImgs) => _.shuffle(prevImgs));
+      setImages((prevImgs) => shuffleWith(prevImgs, _.shuffle));
     }
   }, [isFlipped]);
 
@@ -216,6 +225,7 @@ const Cards = ({ initialAuth }) => {
 
   // helper var to get the current image based on the index in the images array
   const currentImage = images[currentImageIndex];
+  const selectedLocale = isSerbian ? "srb" : isHungarian ? "hu" : "en";
 
   useEffect(() => {
     images.map(photo => {
@@ -334,11 +344,7 @@ const Cards = ({ initialAuth }) => {
           <div className = "maingallerycontainer">
             <Gallery
               photos={images.map(img => {
-                const ratio = img.width / img.height;
-                if (ratio >= 1) {
-                  return { ...img, src: '../static/green2.jpg' }
-                } 
-                return { ...img, src: '../static/green1.jpg' }
+                return { ...img, src: getCardBackSource(img) }
               })}
               renderImage={NumberedGalleryImage}
               onClick={openLightbox}
@@ -352,45 +358,17 @@ const Cards = ({ initialAuth }) => {
             after that there's no need to check for auth*/}
         {
         isLightbox ? (
-          auth ? (
-            isEnglish ? (         
-              <Lightbox
-              imgPath={currentImage.src}
-              txt={currentImage.txt.en}
-              onClose={closeLightbox}
-              showText={checked}
-              />
-          ) 
-          :  isSerbian ? (
-              <Lightbox
-              imgPath={currentImage.src}
-              txt={currentImage.txt.srb}
-              onClose={closeLightbox}
-              showText={checked}
-              /> 
-            )           
-          :  isHungarian ? (
-            <Lightbox
+          <Lightbox
             imgPath={currentImage.src}
-            txt={currentImage.txt.hu}
+            txt={getPromptForLocale(
+              currentImage.txt,
+              Boolean(auth),
+              selectedLocale
+            )}
             onClose={closeLightbox}
             showText={checked}
-            /> 
-          ) : 
-              <Lightbox
-              imgPath={currentImage.src}
-              txt={currentImage.txt.en}
-              onClose={closeLightbox}
-              showText={checked}
-              /> 
-          ) : 
-            <Lightbox
-            imgPath={currentImage.src}
-            txt={currentImage.txt}
-            onClose={closeLightbox}
-            showText={checked}
-            /> 
-          ) :
+          />
+        ) :
          null 
          }
       <style jsx>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/legacy",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  reporter: "line",
+  use: {
+    headless: true,
+    trace: "retain-on-failure",
+  },
+});

--- a/tests/legacy/KNOWN_DEFECTS.md
+++ b/tests/legacy/KNOWN_DEFECTS.md
@@ -1,0 +1,20 @@
+# Legacy defects excluded from the preservation contract
+
+`VIB-STAB-004` records behavior needed during replacement. The suite does not
+turn the following current defects into target requirements:
+
+- The production card lightbox is not exposed as a named dialog and does not
+  demonstrate a focus trap, Escape close, or focus restoration.
+- Gallery images do not consistently expose useful alternative text before the
+  reveal view.
+- Random order is delegated to unseeded `lodash.shuffle`, so an individual
+  order cannot be reproduced.
+- The authenticated browser downloads complete protected image objects and
+  converts them to data URLs.
+- The legacy language control and switch do not yet meet the target component
+  contracts.
+- The legacy route remains large and combines authentication, data access,
+  transforms, state, and rendering.
+
+Target behavior remains authoritative in the product, accessibility, security,
+architecture, and interaction specifications.

--- a/tests/legacy/README.md
+++ b/tests/legacy/README.md
@@ -1,0 +1,23 @@
+# Legacy characterization coverage
+
+Work item: `VIB-STAB-004`
+
+Requirement mapping:
+
+| Requirement | Characterized evidence |
+| --- | --- |
+| MIG-003, AT-031 | Unit and browser fixture suites run in baseline CI before replacement work |
+| Anonymous public dataset | `anonymous-cards.json`, deck-table unit test, anonymous browser journey |
+| Authenticated full dataset | `full-cards.json`, deck-table unit test, full-deck browser journey |
+| Face-up/down | Card-back orientation helper and browser flip assertion |
+| Show/hide prompt | Anonymous browser journey |
+| English/Serbian/Hungarian | Locale unit assertions and full-deck browser journey |
+| Randomization and numbering | Injected shuffle permutation assertion and card-ID order assertion |
+| Routes | Filesystem smoke for `/`, `/cards`, `/about`, `/contact`, and `/login` |
+
+Fixtures use opaque synthetic IDs and synthetic prompt markers. Test output names
+only the route or state under test and does not print production prompts, tokens,
+contact data, signed asset URLs, or account information.
+
+See [KNOWN_DEFECTS.md](KNOWN_DEFECTS.md) for behaviors that are observed but are
+not part of the target preservation contract.

--- a/tests/legacy/fixtures/anonymous-cards.json
+++ b/tests/legacy/fixtures/anonymous-cards.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "anonymous-card-a",
+    "txt": "synthetic-anonymous-prompt-a",
+    "width": 4,
+    "height": 3
+  },
+  {
+    "id": "anonymous-card-b",
+    "txt": "synthetic-anonymous-prompt-b",
+    "width": 3,
+    "height": 4
+  },
+  {
+    "id": "anonymous-card-c",
+    "txt": "synthetic-anonymous-prompt-c",
+    "width": 1,
+    "height": 1
+  }
+]

--- a/tests/legacy/fixtures/full-cards.json
+++ b/tests/legacy/fixtures/full-cards.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "full-card-a",
+    "txt": {
+      "en": "synthetic-en-a",
+      "srb": "synthetic-srb-a",
+      "hu": "synthetic-hu-a"
+    },
+    "width": 4,
+    "height": 3
+  },
+  {
+    "id": "full-card-b",
+    "txt": {
+      "en": "synthetic-en-b",
+      "srb": "synthetic-srb-b",
+      "hu": "synthetic-hu-b"
+    },
+    "width": 3,
+    "height": 4
+  },
+  {
+    "id": "full-card-c",
+    "txt": {
+      "en": "synthetic-en-c",
+      "srb": "synthetic-srb-c",
+      "hu": "synthetic-hu-c"
+    },
+    "width": 1,
+    "height": 1
+  },
+  {
+    "id": "full-card-d",
+    "txt": {
+      "en": "synthetic-en-d",
+      "srb": "synthetic-srb-d",
+      "hu": "synthetic-hu-d"
+    },
+    "width": 16,
+    "height": 9
+  }
+]

--- a/tests/legacy/legacy-cards.spec.ts
+++ b/tests/legacy/legacy-cards.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const anonymousCards = require("./fixtures/anonymous-cards.json");
+const fullCards = require("./fixtures/full-cards.json");
+const behaviorPath = path.resolve(__dirname, "../../lib/legacyCardsBehavior.js");
+
+async function mountLegacyFixture(page) {
+  await page.setContent(`
+    <main>
+      <p id="deck-kind"></p>
+      <button id="anonymous">Anonymous deck</button>
+      <button id="full">Full deck</button>
+      <button id="flip">Flip cards</button>
+      <button id="shuffle">Shuffle cards</button>
+      <label>
+        <input id="show-prompt" type="checkbox" checked />
+        Show prompt
+      </label>
+      <label>
+        Locale
+        <select id="locale">
+          <option value="en">English</option>
+          <option value="srb">Srpski</option>
+          <option value="hu">Magyar</option>
+        </select>
+      </label>
+      <section id="cards" aria-label="Synthetic legacy cards"></section>
+      <section id="reveal" aria-live="polite"></section>
+    </main>
+  `);
+  await page.addScriptTag({ path: behaviorPath });
+  await page.evaluate(
+    ({ anonymousFixture, fullFixture }) => {
+      const behavior = (window as any).LegacyCardsBehavior;
+      let authenticated = false;
+      let flipped = false;
+      let cards = anonymousFixture;
+      let selectedCard = null;
+
+      const renderReveal = () => {
+        const reveal = document.querySelector("#reveal") as HTMLElement;
+        const showPrompt = (document.querySelector("#show-prompt") as HTMLInputElement)
+          .checked;
+        const locale = (document.querySelector("#locale") as HTMLSelectElement).value;
+        reveal.textContent =
+          selectedCard && showPrompt
+            ? behavior.getPromptForLocale(
+                selectedCard.txt,
+                authenticated,
+                locale
+              )
+            : "";
+      };
+
+      const render = () => {
+        const deckKind = document.querySelector("#deck-kind") as HTMLElement;
+        deckKind.textContent = behavior.getDeckTableName(authenticated);
+        const container = document.querySelector("#cards") as HTMLElement;
+        container.replaceChildren(
+          ...cards.map((card) => {
+            const button = document.createElement("button");
+            button.dataset.cardId = card.id;
+            button.dataset.source = flipped
+              ? behavior.getCardBackSource(card)
+              : `synthetic-front-${card.id}`;
+            button.dataset.number = flipped
+              ? String(behavior.getCardNumber(cards.indexOf(card)))
+              : "";
+            button.textContent = card.id;
+            button.addEventListener("click", () => {
+              selectedCard = card;
+              renderReveal();
+            });
+            return button;
+          })
+        );
+        renderReveal();
+      };
+
+      document.querySelector("#anonymous")?.addEventListener("click", () => {
+        authenticated = false;
+        cards = anonymousFixture;
+        selectedCard = null;
+        render();
+      });
+      document.querySelector("#full")?.addEventListener("click", () => {
+        authenticated = true;
+        cards = fullFixture;
+        selectedCard = null;
+        render();
+      });
+      document.querySelector("#flip")?.addEventListener("click", () => {
+        flipped = !flipped;
+        render();
+      });
+      document.querySelector("#shuffle")?.addEventListener("click", () => {
+        cards = behavior.shuffleWith(cards, (items) => items.slice().reverse());
+        render();
+      });
+      document.querySelector("#show-prompt")?.addEventListener("change", renderReveal);
+      document.querySelector("#locale")?.addEventListener("change", renderReveal);
+      render();
+    },
+    { anonymousFixture: anonymousCards, fullFixture: fullCards }
+  );
+}
+
+test("anonymous deck loads, reveals, flips, hides prompts, and shuffles", async ({
+  page,
+}) => {
+  await mountLegacyFixture(page);
+
+  await expect(page.locator("#deck-kind")).toHaveText("vibuco-photos-public");
+  await expect(page.locator("#cards button")).toHaveCount(3);
+  await page.locator("#cards button").first().click();
+  await expect(page.locator("#reveal")).toHaveText(
+    "synthetic-anonymous-prompt-a"
+  );
+
+  await page.locator("#show-prompt").uncheck();
+  await expect(page.locator("#reveal")).toBeEmpty();
+  await page.locator("#flip").click();
+  await expect(page.locator("#cards button").first()).toHaveAttribute(
+    "data-source",
+    "../static/green2.jpg"
+  );
+  await expect(page.locator("#cards button").first()).toHaveAttribute(
+    "data-number",
+    "1"
+  );
+
+  await page.locator("#shuffle").click();
+  await expect(page.locator("#cards button").first()).toHaveAttribute(
+    "data-card-id",
+    "anonymous-card-c"
+  );
+});
+
+test("full deck exposes English, Serbian, and Hungarian prompts", async ({
+  page,
+}) => {
+  await mountLegacyFixture(page);
+  await page.locator("#full").click();
+
+  await expect(page.locator("#deck-kind")).toHaveText("vibuco-photos");
+  await expect(page.locator("#cards button")).toHaveCount(4);
+  await page.locator("#cards button").first().click();
+  await expect(page.locator("#reveal")).toHaveText("synthetic-en-a");
+
+  await page.locator("#locale").selectOption("srb");
+  await expect(page.locator("#reveal")).toHaveText("synthetic-srb-a");
+  await page.locator("#locale").selectOption("hu");
+  await expect(page.locator("#reveal")).toHaveText("synthetic-hu-a");
+});

--- a/tests/legacy/legacyCardsBehavior.test.js
+++ b/tests/legacy/legacyCardsBehavior.test.js
@@ -1,0 +1,74 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  getCardBackSource,
+  getCardNumber,
+  getDeckTableName,
+  getPromptForLocale,
+  shuffleWith,
+} = require("../../lib/legacyCardsBehavior");
+
+const anonymousCards = require("./fixtures/anonymous-cards.json");
+const fullCards = require("./fixtures/full-cards.json");
+
+test("selects the anonymous and authenticated legacy deck tables", () => {
+  assert.equal(getDeckTableName(false), "vibuco-photos-public");
+  assert.equal(getDeckTableName(true), "vibuco-photos");
+});
+
+test("preserves anonymous prompt strings and full-deck locale lookup", () => {
+  assert.equal(
+    getPromptForLocale(anonymousCards[0].txt, false, "hu"),
+    "synthetic-anonymous-prompt-a"
+  );
+  assert.equal(
+    getPromptForLocale(fullCards[0].txt, true, "en"),
+    "synthetic-en-a"
+  );
+  assert.equal(
+    getPromptForLocale(fullCards[0].txt, true, "srb"),
+    "synthetic-srb-a"
+  );
+  assert.equal(
+    getPromptForLocale(fullCards[0].txt, true, "hu"),
+    "synthetic-hu-a"
+  );
+});
+
+test("falls back to approved English when a full-deck locale is absent", () => {
+  assert.equal(
+    getPromptForLocale({ en: "synthetic-en" }, true, "hu"),
+    "synthetic-en"
+  );
+});
+
+test("maps landscape and portrait cards to the current card backs", () => {
+  assert.equal(getCardBackSource({ width: 4, height: 3 }), "../static/green2.jpg");
+  assert.equal(getCardBackSource({ width: 3, height: 4 }), "../static/green1.jpg");
+});
+
+test("numbers flipped cards from one in their current order", () => {
+  assert.equal(getCardNumber(0), 1);
+  assert.equal(getCardNumber(2), 3);
+});
+
+test("delegates shuffle and preserves the input card membership", () => {
+  const shuffled = shuffleWith(anonymousCards, (cards) => cards.slice().reverse());
+  assert.deepEqual(
+    shuffled.map((card) => card.id),
+    ["anonymous-card-c", "anonymous-card-b", "anonymous-card-a"]
+  );
+  assert.deepEqual(
+    [...shuffled].map((card) => card.id).sort(),
+    [...anonymousCards].map((card) => card.id).sort()
+  );
+});
+
+test("keeps the current public route files available without target redirects", () => {
+  for (const route of ["index", "cards", "about", "contact", "login"]) {
+    const routePath = path.resolve(__dirname, `../../pages/${route}.js`);
+    assert.equal(fs.existsSync(routePath), true, `${route}.js should exist`);
+  }
+});


### PR DESCRIPTION
## What changed
Adds synthetic anonymous and full-deck fixtures, helper and browser characterization journeys, known-defect labels, and CI coverage.

## Why
Preserves the valuable legacy card behavior before route-by-route replacement.

## Validation
- Seven unit characterizations passed
- Two Playwright journeys passed
- Build and specification validation passed