### PR TITLE
feat(config): add typed environment boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Target runtime configuration. Copy to .env for local development only.
+# Preview, staging, and production values must come from the environment's
+# secret/configuration store; do not commit populated environment files.
+VIBUCO_ENV=local
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Optional for the local target shell. Required in preview, staging, and
+# production. Leave blank until the corresponding server adapter is enabled.
+DATABASE_URL=
+SESSION_KEY=
+
+# Legacy Pages Router compatibility. These values are consumed by the existing
+# browser AWS path and will be retired by the server identity/media migration.
+USER_POOL_REGION=
+USER_POOL_ID=
+USER_POOL_CLIENT_ID=
+PUBLIC_BUCKET_NAME=
+COMMON_BUCKET_NAME=
+IDENTITY_POOL_ID=
+AUTH_COOKIE_DOMAIN=
+IDP_DOMAIN=
+REDIRECT_SIGN_IN=
+REDIRECT_SIGN_OUT=

--- a/docs/backlog/implementation-work-items.yaml
+++ b/docs/backlog/implementation-work-items.yaml
@@ -190,7 +190,7 @@ items:
     branch_name: agent/vib-plat-002-config-boundary
     commit_prefix: "feat(config):"
     milestone: M2
-    status: in_progress
+    status: done
 
   - id: VIB-PLAT-003
     epic: Observability
@@ -220,7 +220,7 @@ items:
     branch_name: agent/vib-plat-003-telemetry
     commit_prefix: "feat(observability):"
     milestone: M2
-    status: planned
+    status: ready
 
   - id: VIB-PLAT-004
     epic: Platform

--- a/docs/backlog/implementation-work-items.yaml
+++ b/docs/backlog/implementation-work-items.yaml
@@ -190,7 +190,7 @@ items:
     branch_name: agent/vib-plat-002-config-boundary
     commit_prefix: "feat(config):"
     milestone: M2
-    status: ready
+    status: in_progress
 
   - id: VIB-PLAT-003
     epic: Observability

--- a/docs/operations/environment-configuration.md
+++ b/docs/operations/environment-configuration.md
@@ -1,0 +1,55 @@
+# Environment configuration
+
+Work item: `VIB-PLAT-002`
+Requirements: SEC-004, SEC-011, OPS-005, OPS-006
+
+## Typed boundary
+
+Target code reads configuration through `src/platform/config/server.ts` or
+`src/platform/config/public.ts`. Server code must not read target configuration
+directly from `process.env`, and Client Components must not import the server
+module.
+
+`NEXT_PUBLIC_SITE_URL` is the complete public allowlist. It must be an HTTPS
+origin without credentials, query, or fragment; local loopback HTTP is allowed.
+Adding another `NEXT_PUBLIC_` key fails with `CONFIG_PUBLIC_UNKNOWN_KEY` until
+the key receives a security review and is added deliberately to the typed
+public schema and its bundle snapshot.
+
+Server configuration contains `VIBUCO_ENV`, `DATABASE_URL`, and `SESSION_KEY`.
+Database and session values are wrapped as redacting `SecretValue` objects.
+They require the explicit `reveal()` operation for server adapter use and
+serialize as `[REDACTED]`. Validation errors expose stable codes and never raw
+configuration values.
+
+## Environment matrix
+
+| Environment | `VIBUCO_ENV` | Public origin | Database/session schema | Data and access policy |
+| --- | --- | --- | --- | --- |
+| Local | `local` | HTTPS or loopback HTTP | Optional until its adapter is enabled; validated when present | Seeded synthetic data; developer access |
+| Preview | `preview` | HTTPS | Required | Ephemeral synthetic resources; no production credentials or personal data |
+| Staging | `staging` | HTTPS | Required | Production-shaped synthetic resources; team access |
+| Production | `production` | HTTPS | Required | Real isolated resources; least-privilege access |
+
+Each non-local environment supplies its own database URL and session key from
+the selected platform's secret manager. Identity, media, email, and telemetry
+adapters extend the server schema in their owning work items; they must follow
+the same isolation rules and cannot expand the public allowlist implicitly.
+
+## Startup and operations
+
+Call `getServerConfig()` at a server startup boundary before enabling a target
+runtime path. A failure is safe to emit as its `code`, for example
+`CONFIG_SERVER_DATABASE_URL_MISSING`; do not log the raw environment, error
+input, or revealed secret. Local development starts from `.env.example`.
+
+The legacy Pages Router variables remain temporarily documented in
+`.env.example` because the migration still supports the existing browser path.
+They are outside the target typed contract and are removed with the legacy
+identity/media boundary under MIG-011.
+
+## Rollback
+
+This work does not enable a target route or mutate any environment. Reverting
+the configuration modules and this document returns to the VIB-PLAT-001 shell;
+the legacy build variables and static artifact remain unchanged.

--- a/src/platform/config/public.ts
+++ b/src/platform/config/public.ts
@@ -1,0 +1,81 @@
+export const PUBLIC_ENVIRONMENT_KEYS = ["NEXT_PUBLIC_SITE_URL"] as const;
+
+export type PublicEnvironmentKey = (typeof PUBLIC_ENVIRONMENT_KEYS)[number];
+
+export type PublicConfig = Readonly<{
+  siteUrl: string;
+}>;
+
+export type PublicConfigurationErrorCode =
+  | "CONFIG_PUBLIC_UNKNOWN_KEY"
+  | "CONFIG_PUBLIC_SITE_URL_MISSING"
+  | "CONFIG_PUBLIC_SITE_URL_INVALID";
+
+export class PublicConfigurationError extends Error {
+  readonly code: PublicConfigurationErrorCode;
+
+  constructor(code: PublicConfigurationErrorCode) {
+    super(
+      `[${code}] Public environment configuration is invalid. ` +
+        "Review .env.example; configuration values were not logged."
+    );
+    this.name = "PublicConfigurationError";
+    this.code = code;
+  }
+}
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+function invalid(code: PublicConfigurationErrorCode): never {
+  throw new PublicConfigurationError(code);
+}
+
+function parseSiteUrl(rawValue: string | undefined): string {
+  const value = rawValue?.trim();
+  if (!value) invalid("CONFIG_PUBLIC_SITE_URL_MISSING");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return invalid("CONFIG_PUBLIC_SITE_URL_INVALID");
+  }
+
+  const isLocalHttp =
+    parsed.protocol === "http:" &&
+    ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
+  if (parsed.protocol !== "https:" && !isLocalHttp) {
+    invalid("CONFIG_PUBLIC_SITE_URL_INVALID");
+  }
+
+  if (
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== "/" ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    invalid("CONFIG_PUBLIC_SITE_URL_INVALID");
+  }
+
+  return parsed.origin;
+}
+
+export function parsePublicEnvironment(environment: Environment): PublicConfig {
+  const unknownPublicKey = Object.keys(environment).some(
+    (key) =>
+      key.startsWith("NEXT_PUBLIC_") &&
+      !PUBLIC_ENVIRONMENT_KEYS.includes(key as PublicEnvironmentKey)
+  );
+  if (unknownPublicKey) invalid("CONFIG_PUBLIC_UNKNOWN_KEY");
+
+  return Object.freeze({
+    siteUrl: parseSiteUrl(environment.NEXT_PUBLIC_SITE_URL),
+  });
+}
+
+export function getPublicConfig(): PublicConfig {
+  return parsePublicEnvironment({
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+  });
+}

--- a/src/platform/config/server.ts
+++ b/src/platform/config/server.ts
@@ -1,6 +1,145 @@
 import "server-only";
 import { assertEnvironmentBoundary } from "./environment-boundary";
+import { parsePublicEnvironment, type PublicConfig } from "./public";
+
+export const DEPLOYMENT_ENVIRONMENTS = [
+  "local",
+  "preview",
+  "staging",
+  "production",
+] as const;
+
+export type DeploymentEnvironment =
+  (typeof DEPLOYMENT_ENVIRONMENTS)[number];
+
+export type ServerConfigurationErrorCode =
+  | "CONFIG_SERVER_ENVIRONMENT_MISSING"
+  | "CONFIG_SERVER_ENVIRONMENT_INVALID"
+  | "CONFIG_SERVER_SITE_URL_INVALID"
+  | "CONFIG_SERVER_DATABASE_URL_MISSING"
+  | "CONFIG_SERVER_DATABASE_URL_INVALID"
+  | "CONFIG_SERVER_SESSION_KEY_MISSING"
+  | "CONFIG_SERVER_SESSION_KEY_INVALID";
+
+export class ServerConfigurationError extends Error {
+  readonly code: ServerConfigurationErrorCode;
+
+  constructor(code: ServerConfigurationErrorCode) {
+    super(
+      `[${code}] Server environment configuration is invalid. ` +
+        "Review .env.example; configuration values were not logged."
+    );
+    this.name = "ServerConfigurationError";
+    this.code = code;
+  }
+}
+
+export type SecretValue = Readonly<{
+  reveal: () => string;
+  toJSON: () => "[REDACTED]";
+  toString: () => "[REDACTED]";
+}>;
+
+export type ServerConfig = Readonly<{
+  deploymentEnvironment: DeploymentEnvironment;
+  public: PublicConfig;
+  databaseUrl?: SecretValue;
+  sessionKey?: SecretValue;
+}>;
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+function invalid(code: ServerConfigurationErrorCode): never {
+  throw new ServerConfigurationError(code);
+}
+
+function secret(value: string): SecretValue {
+  return Object.freeze({
+    reveal: () => value,
+    toJSON: () => "[REDACTED]" as const,
+    toString: () => "[REDACTED]" as const,
+  });
+}
+
+function parseDeploymentEnvironment(
+  rawValue: string | undefined
+): DeploymentEnvironment {
+  const value = rawValue?.trim();
+  if (!value) invalid("CONFIG_SERVER_ENVIRONMENT_MISSING");
+  if (!DEPLOYMENT_ENVIRONMENTS.includes(value as DeploymentEnvironment)) {
+    invalid("CONFIG_SERVER_ENVIRONMENT_INVALID");
+  }
+  return value as DeploymentEnvironment;
+}
+
+function parseDatabaseUrl(
+  rawValue: string | undefined,
+  required: boolean
+): SecretValue | undefined {
+  const value = rawValue;
+  if (!value) {
+    if (required) invalid("CONFIG_SERVER_DATABASE_URL_MISSING");
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return invalid("CONFIG_SERVER_DATABASE_URL_INVALID");
+  }
+  if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+    invalid("CONFIG_SERVER_DATABASE_URL_INVALID");
+  }
+
+  return secret(value);
+}
+
+function parseSessionKey(
+  rawValue: string | undefined,
+  required: boolean
+): SecretValue | undefined {
+  const value = rawValue;
+  if (!value) {
+    if (required) invalid("CONFIG_SERVER_SESSION_KEY_MISSING");
+    return undefined;
+  }
+  if (value.length < 32) invalid("CONFIG_SERVER_SESSION_KEY_INVALID");
+  return secret(value);
+}
+
+export function parseServerEnvironment(environment: Environment): ServerConfig {
+  assertEnvironmentBoundary(environment);
+  const deploymentEnvironment = parseDeploymentEnvironment(
+    environment.VIBUCO_ENV
+  );
+  const requiresRuntimeServices = deploymentEnvironment !== "local";
+  const publicConfig = parsePublicEnvironment(environment);
+  if (
+    requiresRuntimeServices &&
+    new URL(publicConfig.siteUrl).protocol !== "https:"
+  ) {
+    invalid("CONFIG_SERVER_SITE_URL_INVALID");
+  }
+
+  return Object.freeze({
+    deploymentEnvironment,
+    public: publicConfig,
+    databaseUrl: parseDatabaseUrl(
+      environment.DATABASE_URL,
+      requiresRuntimeServices
+    ),
+    sessionKey: parseSessionKey(
+      environment.SESSION_KEY,
+      requiresRuntimeServices
+    ),
+  });
+}
+
+export function getServerConfig(): ServerConfig {
+  return parseServerEnvironment(process.env);
+}
 
 export function validateServerEnvironment(): void {
-  assertEnvironmentBoundary(process.env);
+  getServerConfig();
 }

--- a/tests/platform/environment-boundary.test.mjs
+++ b/tests/platform/environment-boundary.test.mjs
@@ -5,7 +5,7 @@ import { assertEnvironmentBoundary } from "../../src/platform/config/environment
 test("allows public values that are not privileged credentials", () => {
   assert.doesNotThrow(() =>
     assertEnvironmentBoundary({
-      NEXT_PUBLIC_SITE_NAME: "synthetic-site",
+      NEXT_PUBLIC_SITE_URL: "https://synthetic.example",
     })
   );
 });

--- a/tests/platform/public-configuration.test.mjs
+++ b/tests/platform/public-configuration.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  PUBLIC_ENVIRONMENT_KEYS,
+  parsePublicEnvironment,
+} from "../../src/platform/config/public.ts";
+
+test("public configuration allowlist is an intentional snapshot", () => {
+  assert.deepEqual(PUBLIC_ENVIRONMENT_KEYS, ["NEXT_PUBLIC_SITE_URL"]);
+});
+
+test("normalizes an HTTPS origin and local loopback HTTP", () => {
+  assert.deepEqual(
+    parsePublicEnvironment({
+      NEXT_PUBLIC_SITE_URL: "https://preview.synthetic.example/",
+    }),
+    { siteUrl: "https://preview.synthetic.example" }
+  );
+  assert.deepEqual(
+    parsePublicEnvironment({
+      NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
+    }),
+    { siteUrl: "http://localhost:3000" }
+  );
+});
+
+test("reports missing and malformed public values without echoing input", () => {
+  assert.throws(
+    () => parsePublicEnvironment({}),
+    (error) => error.code === "CONFIG_PUBLIC_SITE_URL_MISSING"
+  );
+
+  const malformedValue = "synthetic-invalid-public-value";
+  assert.throws(
+    () =>
+      parsePublicEnvironment({
+        NEXT_PUBLIC_SITE_URL: malformedValue,
+      }),
+    (error) =>
+      error.code === "CONFIG_PUBLIC_SITE_URL_INVALID" &&
+      !error.message.includes(malformedValue)
+  );
+});
+
+test("rejects insecure remote origins and unknown public keys", () => {
+  assert.throws(
+    () =>
+      parsePublicEnvironment({
+        NEXT_PUBLIC_SITE_URL: "http://synthetic.example",
+      }),
+    (error) => error.code === "CONFIG_PUBLIC_SITE_URL_INVALID"
+  );
+  assert.throws(
+    () =>
+      parsePublicEnvironment({
+        NEXT_PUBLIC_SITE_URL: "https://synthetic.example",
+        NEXT_PUBLIC_DATABASE_URL: "synthetic-secret",
+      }),
+    (error) => error.code === "CONFIG_PUBLIC_UNKNOWN_KEY"
+  );
+});
+
+test("client configuration source references only allowlisted values", async () => {
+  const source = await readFile(
+    new URL("../../src/platform/config/public.ts", import.meta.url),
+    "utf8"
+  );
+  const referencedEnvironmentKeys = Array.from(
+    source.matchAll(/process\.env\.([A-Z0-9_]+)/g),
+    (match) => match[1]
+  );
+
+  assert.deepEqual(referencedEnvironmentKeys, [...PUBLIC_ENVIRONMENT_KEYS]);
+  for (const forbiddenMarker of [
+    "DATABASE_URL",
+    "SESSION_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "server-only",
+  ]) {
+    assert.equal(source.includes(forbiddenMarker), false, forbiddenMarker);
+  }
+});

--- a/tests/platform/server-configuration.test.mjs
+++ b/tests/platform/server-configuration.test.mjs
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+test("server configuration validates every deployment schema and redacts secrets", () => {
+  const moduleUrl = new URL(
+    "../../src/platform/config/server.ts",
+    import.meta.url
+  ).href;
+  const childSource = `
+    import { registerHooks } from "node:module";
+
+    registerHooks({
+      resolve(specifier, context, nextResolve) {
+        if (specifier.startsWith(".") && context.parentURL?.endsWith(".ts")) {
+          return {
+            shortCircuit: true,
+            url: new URL(specifier + ".ts", context.parentURL).href,
+          };
+        }
+        return nextResolve(specifier, context);
+      },
+    });
+
+    const { parseServerEnvironment } = await import(${JSON.stringify(moduleUrl)});
+
+    const validSecrets = {
+      DATABASE_URL: "postgresql://synthetic-user:synthetic-password@db.synthetic.invalid/vibuco",
+      SESSION_KEY: "synthetic-session-key-with-32-characters",
+    };
+    const base = {
+      NEXT_PUBLIC_SITE_URL: "https://synthetic.example",
+    };
+    const cases = [
+      ["local", { ...base, VIBUCO_ENV: "local" }],
+      ["preview", { ...base, ...validSecrets, VIBUCO_ENV: "preview" }],
+      ["staging", { ...base, ...validSecrets, VIBUCO_ENV: "staging" }],
+      ["production", { ...base, ...validSecrets, VIBUCO_ENV: "production" }],
+      ["missing-environment", base],
+      ["invalid-environment", { ...base, VIBUCO_ENV: "qa" }],
+      ["insecure-preview-origin", {
+        ...base,
+        ...validSecrets,
+        VIBUCO_ENV: "preview",
+        NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
+      }],
+      ["missing-database", { ...base, VIBUCO_ENV: "preview", SESSION_KEY: validSecrets.SESSION_KEY }],
+      ["invalid-database", { ...base, VIBUCO_ENV: "preview", ...validSecrets, DATABASE_URL: "synthetic-invalid-database" }],
+      ["missing-session", { ...base, VIBUCO_ENV: "staging", DATABASE_URL: validSecrets.DATABASE_URL }],
+      ["invalid-session", { ...base, VIBUCO_ENV: "production", ...validSecrets, SESSION_KEY: "synthetic-short" }],
+    ];
+
+    const results = cases.map(([name, environment]) => {
+      try {
+        const config = parseServerEnvironment(environment);
+        const serialized = JSON.stringify(config);
+        return {
+          name,
+          ok: true,
+          deploymentEnvironment: config.deploymentEnvironment,
+          serialized,
+          hasDatabase: Boolean(config.databaseUrl),
+          hasSession: Boolean(config.sessionKey),
+          databaseReveals: config.databaseUrl?.reveal() === environment.DATABASE_URL,
+          sessionReveals: config.sessionKey?.reveal() === environment.SESSION_KEY,
+        };
+      } catch (error) {
+        return { name, ok: false, code: error.code, message: error.message };
+      }
+    });
+    console.log(JSON.stringify({ results, validSecrets }));
+  `;
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--conditions=react-server",
+      "--input-type=module",
+      "--eval",
+      childSource,
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(child.status, 0, child.stderr);
+  const { results, validSecrets } = JSON.parse(child.stdout);
+  const byName = Object.fromEntries(results.map((result) => [result.name, result]));
+
+  for (const environment of ["local", "preview", "staging", "production"]) {
+    assert.equal(byName[environment].ok, true, environment);
+    assert.equal(byName[environment].deploymentEnvironment, environment);
+  }
+  assert.equal(byName.local.hasDatabase, false);
+  assert.equal(byName.local.hasSession, false);
+  assert.equal(byName.preview.databaseReveals, true);
+  assert.equal(byName.preview.sessionReveals, true);
+  assert.match(byName.preview.serialized, /\[REDACTED\]/);
+  assert.equal(byName.preview.serialized.includes(validSecrets.DATABASE_URL), false);
+  assert.equal(byName.preview.serialized.includes(validSecrets.SESSION_KEY), false);
+
+  assert.equal(
+    byName["missing-environment"].code,
+    "CONFIG_SERVER_ENVIRONMENT_MISSING"
+  );
+  assert.equal(
+    byName["invalid-environment"].code,
+    "CONFIG_SERVER_ENVIRONMENT_INVALID"
+  );
+  assert.equal(
+    byName["insecure-preview-origin"].code,
+    "CONFIG_SERVER_SITE_URL_INVALID"
+  );
+  assert.equal(
+    byName["missing-database"].code,
+    "CONFIG_SERVER_DATABASE_URL_MISSING"
+  );
+  assert.equal(
+    byName["invalid-database"].code,
+    "CONFIG_SERVER_DATABASE_URL_INVALID"
+  );
+  assert.equal(
+    byName["missing-session"].code,
+    "CONFIG_SERVER_SESSION_KEY_MISSING"
+  );
+  assert.equal(
+    byName["invalid-session"].code,
+    "CONFIG_SERVER_SESSION_KEY_INVALID"
+  );
+
+  for (const result of results.filter(({ ok }) => !ok)) {
+    assert.equal(result.message.includes("synthetic-invalid-database"), false);
+    assert.equal(result.message.includes("synthetic-short"), false);
+  }
+});


### PR DESCRIPTION
## What changed

Adds the VIB-PLAT-002 typed configuration boundary for target code:

- typed server and public environment schemas
- an explicit `NEXT_PUBLIC_SITE_URL` allowlist
- safe configuration error codes and redacting server secret wrappers
- documented local, preview, staging, and production configuration rules
- unit coverage for validation, redaction, and client-boundary behavior

## Why

Target configuration previously lacked a typed, reviewed boundary between public runtime values and server-only secrets.

## Validation

- specification validation
- strict TypeScript check
- platform configuration tests
- platform boundary and route-manifest scans
- legacy/stability unit tests
- production build
- Playwright legacy-card tests

## Impact

No target route or production configuration is enabled by this change. Legacy Pages Router environment variables remain supported until the scheduled server identity/media migration.