### PR TITLE
feat(observability): add telemetry foundation

### DIFF
--- a/docs/backlog/implementation-work-items.yaml
+++ b/docs/backlog/implementation-work-items.yaml
@@ -220,7 +220,7 @@ items:
     branch_name: agent/vib-plat-003-telemetry
     commit_prefix: "feat(observability):"
     milestone: M2
-    status: ready
+    status: in_progress
 
   - id: VIB-PLAT-004
     epic: Platform

--- a/docs/backlog/implementation-work-items.yaml
+++ b/docs/backlog/implementation-work-items.yaml
@@ -220,7 +220,7 @@ items:
     branch_name: agent/vib-plat-003-telemetry
     commit_prefix: "feat(observability):"
     milestone: M2
-    status: in_progress
+    status: done
 
   - id: VIB-PLAT-004
     epic: Platform
@@ -249,7 +249,7 @@ items:
     branch_name: agent/vib-plat-004-feature-flags
     commit_prefix: "feat(flags):"
     milestone: M2
-    status: planned
+    status: ready
 
   - id: VIB-UI-001
     epic: Design system

--- a/docs/operations/telemetry-foundation.md
+++ b/docs/operations/telemetry-foundation.md
@@ -1,0 +1,31 @@
+# Telemetry foundation
+
+Work item: `VIB-PLAT-003`
+Requirements: OBS-001 through OBS-007, OBS-013, SEC-015
+
+## Contract
+
+Target route handlers use `instrumentRequest` from
+`src/platform/telemetry/request-instrumentation.ts`. It creates or propagates
+the request and trace IDs, returns both in response headers, and records a
+bounded request-completion signal. The schema contains only timestamp,
+severity, service, environment, route template, method, status class, outcome,
+duration, correlation IDs, actor class, and an optional stable error code.
+
+The foundation rejects arbitrary routes, methods, durations, and error text.
+It has no product-event API; product analytics remains a separate allowlisted
+contract.
+
+## Failure behavior
+
+Exporter errors are caught, increment `telemetry.dropped`, and cannot change
+the route response. Provider adapters are deferred pending
+`HUMAN-DECISION-002`; they receive only the typed signal and must not add raw
+request headers, cookies, URLs, identities, or content.
+
+## Rollback
+
+Remove the route wrapper or exporter adapter while retaining correlation
+headers. The legacy static routes remain independent. See
+[telemetry unavailable](../runbooks/telemetry-unavailable.md) for the
+operational response.

--- a/docs/runbooks/telemetry-unavailable.md
+++ b/docs/runbooks/telemetry-unavailable.md
@@ -1,0 +1,26 @@
+# Telemetry unavailable
+
+Work item: `VIB-PLAT-003`
+
+## Symptoms and impact
+
+The `telemetry.dropped` counter increases or the telemetry exporter reports an
+outage. User requests remain available; operational visibility is reduced.
+
+## Immediate checks
+
+1. Confirm application requests still return their `x-request-id` header.
+2. Check the exporter dependency health and recent deploy markers.
+3. Inspect only request IDs, trace IDs, route templates, and stable error codes.
+
+## Safe mitigation and rollback
+
+Disable or roll back the exporter adapter only. Do not log raw request headers,
+cookies, signed URLs, prompts, client data, or configuration values to replace
+the missing telemetry. The provider-neutral foundation can remain enabled.
+
+## Escalation and verification
+
+Escalate to the reliability owner if loss persists through two observation
+windows. Verify recovery when exporter delivery succeeds and `telemetry.dropped`
+stops increasing for the same request volume.

--- a/scripts/check-platform-boundaries.mjs
+++ b/scripts/check-platform-boundaries.mjs
@@ -32,12 +32,12 @@ for (const filePath of await sourceFiles(sourceRoot)) {
     violations.push(`${relativePath}: client module imports a server boundary`);
   }
 
-  if (
-    /src[\\/]platform[\\/](?:config[\\/]server|telemetry[\\/]request-context)\.ts$/.test(
+  const requiresServerOnly =
+    /src[\\/]platform[\\/](?:config[\\/]server|telemetry[\\/](?:foundation|request-context|request-instrumentation))\.ts$/.test(
       filePath
-    ) &&
-    !/import\s+["']server-only["'];/.test(source)
-  ) {
+    ) || /src[\\/]instrumentation\.ts$/.test(filePath);
+
+  if (requiresServerOnly && !/import\s+["']server-only["'];/.test(source)) {
     violations.push(`${relativePath}: privileged platform module lacks server-only`);
   }
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,6 @@
+import "server-only";
+
+export async function register(): Promise<void> {
+  // Provider adapters are intentionally deferred until HUMAN-DECISION-002.
+  // The request wrapper is provider-neutral and remains safe when no exporter exists.
+}

--- a/src/platform/telemetry/correlation.ts
+++ b/src/platform/telemetry/correlation.ts
@@ -1,0 +1,24 @@
+import { randomUUID } from "node:crypto";
+
+export type RequestContext = Readonly<{
+  requestId: string;
+  traceId: string;
+}>;
+
+const SAFE_CORRELATION_VALUE = /^[A-Za-z0-9._:/-]{1,200}$/;
+
+function safeHeader(value: string | null): string | undefined {
+  return value && SAFE_CORRELATION_VALUE.test(value) ? value : undefined;
+}
+
+export function createRequestContext(
+  requestHeaders: Pick<Headers, "get">
+): RequestContext {
+  const requestId = safeHeader(requestHeaders.get("x-request-id")) ?? randomUUID();
+  const traceId =
+    safeHeader(requestHeaders.get("x-trace-id")) ??
+    safeHeader(requestHeaders.get("traceparent")) ??
+    requestId;
+
+  return { requestId, traceId };
+}

--- a/src/platform/telemetry/foundation.ts
+++ b/src/platform/telemetry/foundation.ts
@@ -1,0 +1,113 @@
+import "server-only";
+import type { RequestContext } from "./correlation";
+
+export const TELEMETRY_OUTCOMES = ["success", "client_error", "server_error"] as const;
+export const ACTOR_CLASSES = ["anonymous", "facilitator", "administrator", "system"] as const;
+export const TELEMETRY_ENVIRONMENTS = ["local", "preview", "staging", "production"] as const;
+
+export type TelemetryOutcome = (typeof TELEMETRY_OUTCOMES)[number];
+export type ActorClass = (typeof ACTOR_CLASSES)[number];
+export type TelemetryEnvironment = (typeof TELEMETRY_ENVIRONMENTS)[number];
+
+export type RequestCompletionSignal = Readonly<{
+  kind: "request_completion";
+  timestamp: string;
+  severity: "info" | "error";
+  service: "vibuco";
+  environment: TelemetryEnvironment;
+  route: string;
+  method: string;
+  statusClass: "2xx" | "4xx" | "5xx";
+  outcome: TelemetryOutcome;
+  durationMs: number;
+  requestId: string;
+  traceId: string;
+  actorClass: ActorClass;
+  errorCode?: string;
+}>;
+
+export type TelemetrySignal = RequestCompletionSignal;
+
+export interface TelemetryExporter {
+  export(signal: TelemetrySignal): Promise<void>;
+}
+
+export type Telemetry = Readonly<{
+  recordRequestCompletion: (
+    context: RequestContext,
+    details: Readonly<{
+      route: string;
+      method: string;
+      status: number;
+      durationMs: number;
+      actorClass: ActorClass;
+      errorCode?: string;
+    }>
+  ) => Promise<void>;
+  droppedCount: () => number;
+}>;
+
+const SAFE_ERROR_CODE = /^[A-Z][A-Z0-9_]{2,80}$/;
+const SAFE_ROUTE = /^\/[A-Za-z0-9_./{}-]{0,200}$/;
+const SAFE_METHOD = /^(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)$/;
+
+function toStatusClass(status: number): "2xx" | "4xx" | "5xx" {
+  if (status >= 500) return "5xx";
+  if (status >= 400) return "4xx";
+  return "2xx";
+}
+
+function toOutcome(status: number): TelemetryOutcome {
+  if (status >= 500) return "server_error";
+  if (status >= 400) return "client_error";
+  return "success";
+}
+
+function assertSafeDetails(details: Parameters<Telemetry["recordRequestCompletion"]>[1]): void {
+  if (!SAFE_ROUTE.test(details.route) || !SAFE_METHOD.test(details.method)) {
+    throw new Error("Telemetry route or method is invalid");
+  }
+  if (!Number.isFinite(details.durationMs) || details.durationMs < 0) {
+    throw new Error("Telemetry duration is invalid");
+  }
+  if (details.errorCode && !SAFE_ERROR_CODE.test(details.errorCode)) {
+    throw new Error("Telemetry error code is invalid");
+  }
+}
+
+export function createTelemetry(
+  exporter: TelemetryExporter,
+  environment: TelemetryEnvironment = "local"
+): Telemetry {
+  let dropped = 0;
+
+  return Object.freeze({
+    async recordRequestCompletion(context, details) {
+      assertSafeDetails(details);
+      const statusClass = toStatusClass(details.status);
+      const signal: RequestCompletionSignal = {
+        kind: "request_completion",
+        timestamp: new Date().toISOString(),
+        severity: statusClass === "5xx" ? "error" : "info",
+        service: "vibuco",
+        environment,
+        route: details.route,
+        method: details.method,
+        statusClass,
+        outcome: toOutcome(details.status),
+        durationMs: Math.round(details.durationMs),
+        requestId: context.requestId,
+        traceId: context.traceId,
+        actorClass: details.actorClass,
+        ...(details.errorCode ? { errorCode: details.errorCode } : {}),
+      };
+
+      try {
+        await exporter.export(signal);
+      } catch {
+        dropped += 1;
+      }
+    },
+    droppedCount: () => dropped,
+  });
+}

--- a/src/platform/telemetry/request-context.ts
+++ b/src/platform/telemetry/request-context.ts
@@ -1,26 +1,10 @@
 import "server-only";
-import { randomUUID } from "node:crypto";
 import { headers } from "next/headers";
+import { createRequestContext, type RequestContext } from "./correlation";
 
-export type RequestContext = Readonly<{
-  requestId: string;
-  traceId: string;
-}>;
-
-const SAFE_CORRELATION_VALUE = /^[A-Za-z0-9._:/-]{1,200}$/;
-
-function safeHeader(value: string | null): string | undefined {
-  return value && SAFE_CORRELATION_VALUE.test(value) ? value : undefined;
-}
+export { createRequestContext, type RequestContext };
 
 export async function getRequestContext(): Promise<RequestContext> {
   const requestHeaders = await headers();
-  const requestId =
-    safeHeader(requestHeaders.get("x-request-id")) ?? randomUUID();
-  const traceId =
-    safeHeader(requestHeaders.get("x-trace-id")) ??
-    safeHeader(requestHeaders.get("traceparent")) ??
-    requestId;
-
-  return { requestId, traceId };
+  return createRequestContext(requestHeaders);
 }

--- a/src/platform/telemetry/request-instrumentation.ts
+++ b/src/platform/telemetry/request-instrumentation.ts
@@ -1,0 +1,48 @@
+import "server-only";
+import { createRequestContext, type RequestContext } from "./correlation";
+import type { ActorClass, Telemetry } from "./foundation";
+
+export type InstrumentedRequestOptions = Readonly<{
+  route: string;
+  actorClass: ActorClass;
+}>;
+
+function responseWithCorrelationHeaders(
+  response: Response,
+  context: RequestContext
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set("x-request-id", context.requestId);
+  headers.set("x-trace-id", context.traceId);
+  return new Response(response.body, { headers, status: response.status, statusText: response.statusText });
+}
+
+export async function instrumentRequest(
+  request: Request,
+  options: InstrumentedRequestOptions,
+  telemetry: Telemetry,
+  handler: (context: RequestContext) => Promise<Response>
+): Promise<Response> {
+  const context = createRequestContext(request.headers);
+  const startedAt = performance.now();
+  let response: Response;
+  let errorCode: string | undefined;
+
+  try {
+    response = await handler(context);
+  } catch {
+    errorCode = "INTERNAL_ERROR";
+    response = new Response(null, { status: 500 });
+  }
+
+  const correlatedResponse = responseWithCorrelationHeaders(response, context);
+  void telemetry.recordRequestCompletion(context, {
+    route: options.route,
+    method: request.method,
+    status: correlatedResponse.status,
+    durationMs: performance.now() - startedAt,
+    actorClass: options.actorClass,
+    ...(errorCode ? { errorCode } : {}),
+  });
+  return correlatedResponse;
+}

--- a/tests/platform/request-instrumentation.test.mjs
+++ b/tests/platform/request-instrumentation.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+test("request instrumentation propagates correlation and tolerates telemetry outage", () => {
+  const foundationUrl = new URL(
+    "../../src/platform/telemetry/foundation.ts",
+    import.meta.url
+  ).href;
+  const instrumentationUrl = new URL(
+    "../../src/platform/telemetry/request-instrumentation.ts",
+    import.meta.url
+  ).href;
+  const childSource = `
+    import { registerHooks } from "node:module";
+    registerHooks({ resolve(specifier, context, nextResolve) {
+      if (specifier.startsWith(".") && context.parentURL?.endsWith(".ts")) {
+        return { shortCircuit: true, url: new URL(specifier + ".ts", context.parentURL).href };
+      }
+      return nextResolve(specifier, context);
+    }});
+    const { createTelemetry } = await import(${JSON.stringify(foundationUrl)});
+    const { instrumentRequest } = await import(${JSON.stringify(instrumentationUrl)});
+    const signals = [];
+    const telemetry = createTelemetry({ export: async (signal) => signals.push(signal) });
+    const response = await instrumentRequest(
+      new Request("https://vibuco.example/api/health", { headers: { "x-request-id": "request-123" } }),
+      { route: "/api/health", actorClass: "anonymous" }, telemetry,
+      async () => new Response("ok", { status: 200 })
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    const failing = createTelemetry({ export: async () => { throw new Error("unavailable"); } });
+    const recovered = await instrumentRequest(
+      new Request("https://vibuco.example/api/health"),
+      { route: "/api/health", actorClass: "anonymous" }, failing,
+      async () => new Response("ok")
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    console.log(JSON.stringify({ requestId: response.headers.get("x-request-id"), traceId: response.headers.get("x-trace-id"), signalRequestId: signals[0].requestId, recovered: recovered.status, dropped: failing.droppedCount() }));
+  `;
+  const child = spawnSync(
+    process.execPath,
+    ["--conditions=react-server", "--input-type=module", "--eval", childSource],
+    { encoding: "utf8" }
+  );
+  assert.equal(child.status, 0, child.stderr);
+  const result = JSON.parse(child.stdout);
+  assert.equal(result.requestId, "request-123");
+  assert.equal(result.traceId, "request-123");
+  assert.equal(result.signalRequestId, "request-123");
+  assert.equal(result.recovered, 200);
+  assert.equal(result.dropped, 1);
+});

--- a/tests/platform/telemetry-foundation.test.mjs
+++ b/tests/platform/telemetry-foundation.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+test("telemetry uses an allowlisted schema and records exporter loss safely", () => {
+  const moduleUrl = new URL(
+    "../../src/platform/telemetry/foundation.ts",
+    import.meta.url
+  ).href;
+  const childSource = `
+    import { registerHooks } from "node:module";
+    registerHooks({ resolve(specifier, context, nextResolve) {
+      if (specifier.startsWith(".") && context.parentURL?.endsWith(".ts")) {
+        return { shortCircuit: true, url: new URL(specifier + ".ts", context.parentURL).href };
+      }
+      return nextResolve(specifier, context);
+    }});
+    const { createTelemetry } = await import(${JSON.stringify(moduleUrl)});
+    const signals = [];
+    const telemetry = createTelemetry({ export: async (signal) => signals.push(signal) });
+    await telemetry.recordRequestCompletion(
+      { requestId: "req-123", traceId: "trace-456" },
+      { route: "/api/health", method: "GET", status: 200, durationMs: 12.4, actorClass: "anonymous" }
+    );
+    let rejected = false;
+    try {
+      await telemetry.recordRequestCompletion(
+        { requestId: "req-123", traceId: "trace-456" },
+        { route: "/api/health?token=secret", method: "GET", status: 500, durationMs: 1, actorClass: "system", errorCode: "database password leaked" }
+      );
+    } catch { rejected = true; }
+    const failing = createTelemetry({ export: async () => { throw new Error("unavailable"); } });
+    await failing.recordRequestCompletion(
+      { requestId: "req-123", traceId: "trace-456" },
+      { route: "/api/health", method: "GET", status: 503, durationMs: 1, actorClass: "system", errorCode: "DEPENDENCY_UNAVAILABLE" }
+    );
+    console.log(JSON.stringify({ signal: signals[0], rejected, dropped: failing.droppedCount() }));
+  `;
+  const child = spawnSync(
+    process.execPath,
+    ["--conditions=react-server", "--input-type=module", "--eval", childSource],
+    { encoding: "utf8" }
+  );
+  assert.equal(child.status, 0, child.stderr);
+  const { signal, rejected, dropped } = JSON.parse(child.stdout);
+  assert.deepEqual(Object.keys(signal).sort(), [
+    "actorClass", "durationMs", "environment", "kind", "method", "outcome", "requestId", "route", "service", "severity", "statusClass", "timestamp", "traceId",
+  ]);
+  assert.equal(signal.outcome, "success");
+  assert.equal(signal.statusClass, "2xx");
+  assert.equal(rejected, true);
+  assert.equal(dropped, 1);
+});


### PR DESCRIPTION
## What changed

Implements VIB-PLAT-003's provider-neutral telemetry foundation:

- request and trace correlation helpers
- a strict structured request-completion schema with bounded labels
- response propagation for `x-request-id` and `x-trace-id`
- safe telemetry loss counting when an exporter fails
- server-only boundary checks, operational contract, and outage runbook

## Why

The target application needs reliable, privacy-safe correlation and operational telemetry before target routes, auth, media, and data adapters are introduced.

## Validation

- strict TypeScript check
- platform telemetry/configuration tests
- platform server-only boundary scan
- specification validation
- legacy/stability unit tests
- route-manifest smoke check
- production build

## Impact

No telemetry vendor or runtime App Router endpoint is enabled. The route wrapper is ready for the first target route, and exporter failures cannot affect user responses.